### PR TITLE
fix: Explicitly set the disabled field to false

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,8 @@ func (c *powerDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 	// Add the record, only if it doesn't exist already
 	content := quote(ch.Key)
 	if _, ok := findRecord(records, content); !ok {
-		records = append(records, powerdns.Record{Content: &content})
+		disabled := false
+		records = append(records, powerdns.Record{Disabled: &disabled, Content: &content})
 	}
 
 	txtType := powerdns.RRTypeTXT


### PR DESCRIPTION
This seems to be required in older versions of PowerDNS, as reported in #11.

Resolves #11