### PR TITLE
Add securityContext configuration

### DIFF
--- a/deploy/cert-manager-webhook-pdns/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-pdns/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "cert-manager-webhook-pdns.fullname" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
@@ -34,6 +38,10 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               scheme: HTTPS

--- a/deploy/cert-manager-webhook-pdns/values.yaml
+++ b/deploy/cert-manager-webhook-pdns/values.yaml
@@ -41,3 +41,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+containerSecurityContext: {}
+podSecurityContext: {}


### PR DESCRIPTION

Hey,

Adding security context would be valuable when running on cluster where we want to use restricted policies for security reasons.

Fixes https://github.com/zachomedia/cert-manager-webhook-pdns/issues/14