### PR TITLE
fix: get proxy from env when using custom CA bundles

### DIFF
--- a/main.go
+++ b/main.go
@@ -277,6 +277,7 @@ func (c *powerDNSProviderSolver) init(config *apiextensionsv1.JSON, namespace st
 		}
 
 		httpClient.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				RootCAs: caBundle,
 			},


### PR DESCRIPTION
Fixes #17 

When creating the custom transport to use the provided CA bundle, no proxy configuration was provided.
By default, the http.Client use the http.DefaultTransport with Proxy set to ProxyFromEnvironment.