### PR TITLE
fix: Use DefaultTransport with custom CA bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ clean:
 	go clean -testcache
 
 verify:
-	TEST_ASSET_ETCD=_out/kubebuilder/bin/etcd TEST_ASSET_KUBE_APISERVER=_out/kubebuilder/bin/kube-apiserver TEST_ASSET_KUBECTL=_out/kubebuilder/bin/kubectl TEST_DNS_SERVER="127.0.0.1:53" TEST_ZONE_NAME=example.ca. go test .
+	TEST_ASSET_ETCD=_out/kubebuilder/bin/etcd TEST_ASSET_KUBE_APISERVER=_out/kubebuilder/bin/kube-apiserver TEST_ASSET_KUBECTL=_out/kubebuilder/bin/kubectl TEST_DNS_SERVER="127.0.0.1:53" TEST_ZONE_NAME=example.ca. go test -v -run "^TestNoProxy.*"
+	TEST_ASSET_ETCD=_out/kubebuilder/bin/etcd TEST_ASSET_KUBE_APISERVER=_out/kubebuilder/bin/kube-apiserver TEST_ASSET_KUBECTL=_out/kubebuilder/bin/kubectl TEST_DNS_SERVER="127.0.0.1:53" TEST_ZONE_NAME=example.ca. HTTP_PROXY="127.0.0.1:3128" HTTPS_PROXY="127.0.0.1:3128" go test -v -run "^TestProxy.*"
 
 test: verify
 

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -21,5 +21,12 @@ services:
       - ./testdata/pdns/docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
     depends_on:
       - pdns
+
+  proxy:
+    image: ubuntu/squid:5.2-22.04_beta
+    ports:
+      - '3128:3128'
+    volumes:
+      - ./testdata/pdns/docker/squid/squid.conf:/etc/squid/squid.conf
 volumes:
   data: {}

--- a/main.go
+++ b/main.go
@@ -276,11 +276,12 @@ func (c *powerDNSProviderSolver) init(config *apiextensionsv1.JSON, namespace st
 			return nil, cfg, fmt.Errorf("failed to load certificate(s) from CA bundle")
 		}
 
-		httpClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: caBundle,
-			},
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{
+			RootCAs: caBundle,
 		}
+
+		httpClient.Transport = transport
 	}
 
 	return powerdns.NewClient(cfg.Host, "localhost", map[string]string{"X-API-Key": apiKey}, httpClient), cfg, nil

--- a/main_test.go
+++ b/main_test.go
@@ -28,12 +28,20 @@ func test(t *testing.T, manifestPath string) {
 	fixture.RunConformance(t)
 }
 
-func TestRunsSuiteNoTLS(t *testing.T) {
+func TestNoProxyNoTLS(t *testing.T) {
 	test(t, "_out/testdata/no-tls")
 }
 
-func TestRunsSuiteTLS(t *testing.T) {
+func TestNoProxyTLS(t *testing.T) {
 	test(t, "_out/testdata/tls")
+}
+
+func TestProxyNoTLS(t *testing.T) {
+	test(t, "_out/testdata/no-tls-with-proxy")
+}
+
+func TestProxyTLS(t *testing.T) {
+	test(t, "_out/testdata/tls-with-proxy")
 }
 
 func getEnv(key, fallback string) string {

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -14,16 +14,21 @@ subjectAltName = @alternate_names
 
 [ alternate_names ]
 DNS.1 = localhost
+DNS.2 = web
 IP.1  = 127.0.0.1
 IP.2  = ::1
 EOF
 
 openssl req -x509 -config _out/openssl.conf -newkey rsa:4096 -keyout _out/key.pem -out _out/cert.pem -sha256 -days 30 -nodes -subj '/CN=localhost'
 
-mkdir -p _out/testdata/tls
-cp testdata/pdns/test/tls/apikey.yml _out/testdata/tls/apikey.yml
-sed "s#__CERT__#$(base64 -w0 _out/cert.pem)#g" testdata/pdns/test/tls/config.json > _out/testdata/tls/config.json
+for suite in tls tls-with-proxy; do
+  mkdir -p _out/testdata/${suite}
+  cp testdata/pdns/test/${suite}/apikey.yml _out/testdata/${suite}/apikey.yml
+  sed "s#__CERT__#$(base64 -w0 _out/cert.pem)#g" testdata/pdns/test/${suite}/config.json > _out/testdata/${suite}/config.json
+done
 
 # No TLS
-mkdir -p _out/testdata/no-tls
-cp testdata/pdns/test/no-tls/{config.json,apikey.yml} _out/testdata/no-tls
+for suite in no-tls no-tls-with-proxy; do
+  mkdir -p _out/testdata/${suite}
+  cp testdata/pdns/test/${suite}/{config.json,apikey.yml} _out/testdata/${suite}
+done

--- a/testdata/pdns/docker/squid/squid.conf
+++ b/testdata/pdns/docker/squid/squid.conf
@@ -1,0 +1,4 @@
+http_access allow all
+http_port 3128
+coredump_dir /var/spool/squid
+logfile_rotate 0

--- a/testdata/pdns/test/no-tls-with-proxy/apikey.yml
+++ b/testdata/pdns/test/no-tls-with-proxy/apikey.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pdns-api-key
+type: Opaque
+data:
+  key: dGVzdDEyMw==

--- a/testdata/pdns/test/no-tls-with-proxy/config.json
+++ b/testdata/pdns/test/no-tls-with-proxy/config.json
@@ -1,0 +1,8 @@
+{
+    "host": "http://pdns:8080",
+    "apiKeySecretRef": {
+        "name": "pdns-api-key",
+        "key": "key"
+    },
+    "ttl": 10
+}

--- a/testdata/pdns/test/tls-with-proxy/apikey.yml
+++ b/testdata/pdns/test/tls-with-proxy/apikey.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pdns-api-key
+type: Opaque
+data:
+  key: dGVzdDEyMw==

--- a/testdata/pdns/test/tls-with-proxy/config.json
+++ b/testdata/pdns/test/tls-with-proxy/config.json
@@ -1,0 +1,9 @@
+{
+    "host": "https://web:8443",
+    "apiKeySecretRef": {
+        "name": "pdns-api-key",
+        "key": "key"
+    },
+    "ttl": 10,
+    "caBundle": "__CERT__"
+}


### PR DESCRIPTION
Ensures that other default settings in DefaultTransport, like proxy settings, are used.

Resolves #17, Closes #18