### PR TITLE
feat: Add setting for editing only allowed zones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ clean:
 	go clean -testcache
 
 verify:
-	TEST_ASSET_ETCD=_out/kubebuilder/bin/etcd TEST_ASSET_KUBE_APISERVER=_out/kubebuilder/bin/kube-apiserver TEST_ASSET_KUBECTL=_out/kubebuilder/bin/kubectl TEST_DNS_SERVER="127.0.0.1:53" TEST_ZONE_NAME=example.ca. HTTP_PROXY="127.0.0.1:3128" HTTPS_PROXY="127.0.0.1:3128" go test -v -run "TestIsAllowedZones"
+	TEST_ASSET_ETCD=_out/kubebuilder/bin/etcd TEST_ASSET_KUBE_APISERVER=_out/kubebuilder/bin/kube-apiserver TEST_ASSET_KUBECTL=_out/kubebuilder/bin/kubectl TEST_DNS_SERVER="127.0.0.1:53" TEST_ZONE_NAME=example.ca. HTTP_PROXY="127.0.0.1:3128" HTTPS_PROXY="127.0.0.1:3128" NO_PROXY="proxy.golang.org" go test -v -run "TestIsAllowedZones"
 	TEST_ASSET_ETCD=_out/kubebuilder/bin/etcd TEST_ASSET_KUBE_APISERVER=_out/kubebuilder/bin/kube-apiserver TEST_ASSET_KUBECTL=_out/kubebuilder/bin/kubectl TEST_DNS_SERVER="127.0.0.1:53" TEST_ZONE_NAME=example.ca. go test -v -run "^TestNoProxy.*"
-	TEST_ASSET_ETCD=_out/kubebuilder/bin/etcd TEST_ASSET_KUBE_APISERVER=_out/kubebuilder/bin/kube-apiserver TEST_ASSET_KUBECTL=_out/kubebuilder/bin/kubectl TEST_DNS_SERVER="127.0.0.1:53" TEST_ZONE_NAME=example.ca. HTTP_PROXY="127.0.0.1:3128" HTTPS_PROXY="127.0.0.1:3128" go test -v -run "^TestProxy.*"
+	TEST_ASSET_ETCD=_out/kubebuilder/bin/etcd TEST_ASSET_KUBE_APISERVER=_out/kubebuilder/bin/kube-apiserver TEST_ASSET_KUBECTL=_out/kubebuilder/bin/kubectl TEST_DNS_SERVER="127.0.0.1:53" TEST_ZONE_NAME=example.ca. HTTP_PROXY="127.0.0.1:3128" HTTPS_PROXY="127.0.0.1:3128" NO_PROXY="proxy.golang.org" go test -v -run "^TestProxy.*"
 
 test: verify
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ clean:
 	go clean -testcache
 
 verify:
+	TEST_ASSET_ETCD=_out/kubebuilder/bin/etcd TEST_ASSET_KUBE_APISERVER=_out/kubebuilder/bin/kube-apiserver TEST_ASSET_KUBECTL=_out/kubebuilder/bin/kubectl TEST_DNS_SERVER="127.0.0.1:53" TEST_ZONE_NAME=example.ca. HTTP_PROXY="127.0.0.1:3128" HTTPS_PROXY="127.0.0.1:3128" go test -v -run "TestIsAllowedZones"
 	TEST_ASSET_ETCD=_out/kubebuilder/bin/etcd TEST_ASSET_KUBE_APISERVER=_out/kubebuilder/bin/kube-apiserver TEST_ASSET_KUBECTL=_out/kubebuilder/bin/kubectl TEST_DNS_SERVER="127.0.0.1:53" TEST_ZONE_NAME=example.ca. go test -v -run "^TestNoProxy.*"
 	TEST_ASSET_ETCD=_out/kubebuilder/bin/etcd TEST_ASSET_KUBE_APISERVER=_out/kubebuilder/bin/kube-apiserver TEST_ASSET_KUBECTL=_out/kubebuilder/bin/kubectl TEST_DNS_SERVER="127.0.0.1:53" TEST_ZONE_NAME=example.ca. HTTP_PROXY="127.0.0.1:3128" HTTPS_PROXY="127.0.0.1:3128" go test -v -run "^TestProxy.*"
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ spec:
               # Timeout for requests to the PDNS api server
               # (in seconds)
               timeout: 30
+
+              # If the server is only allowed to edit certain zones; the
+              # default is an empty list, allowing everything.
+              allowed-zones:
+                - example.com.
+                - example.org.
+                - example.net.
 ```
 
 And then you can issue a cert:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ spec:
 
               # If the server is only allowed to edit certain zones; the
               # default is an empty list, allowing everything.
+              # *IMPORTANT*: Remember the trailing dot to make the zone-name
+              # fully qualified.
               allowed-zones:
                 - example.com.
                 - example.org.

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -28,5 +28,9 @@ services:
       - '3128:3128'
     volumes:
       - ./testdata/pdns/docker/squid/squid.conf:/etc/squid/squid.conf
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
 volumes:
   data: {}

--- a/main_test.go
+++ b/main_test.go
@@ -50,3 +50,28 @@ func getEnv(key, fallback string) string {
 	}
 	return fallback
 }
+
+func TestIsAllowedZones(t *testing.T) {
+	cfg := powerDNSProviderConfig{
+		AllowedZones: []string{"example.com.", "example.org."},
+	}
+
+	tests := []struct {
+		zone    string
+		matched bool
+	}{
+		{"foo.example.com.", true},
+		{"foo.example.net.", false},
+		{"example.com.", true},
+		{"notexample.com.", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.zone, func(t *testing.T) {
+			match := cfg.IsAllowedZone(tt.zone)
+			if match != tt.matched {
+				t.Errorf("Unexpected IsAllowedZone(%s) = %t, expected %t", tt.zone, match, tt.matched)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We host a lot of different zones; while we do have permissions set up in front of PowerDNS, it would also be nice to have defence-in-depth against unintended changes.