### PR TITLE
added possibility to set a priorityClassName

### DIFF
--- a/deploy/cert-manager-webhook-pdns/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-pdns/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"

--- a/deploy/cert-manager-webhook-pdns/values.yaml
+++ b/deploy/cert-manager-webhook-pdns/values.yaml
@@ -58,3 +58,5 @@ containerSecurityContext:
 podAnnotations: {}
 
 podSecurityContext: {}
+
+priorityClassName: ""


### PR DESCRIPTION
This gives the possibility to set a [priorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) on the deployment. Nothing changes with the default values file.