### PR TITLE
fix: Fix panic on missing API key (Resolves #39)

### DIFF
--- a/main.go
+++ b/main.go
@@ -264,7 +264,7 @@ func (c *powerDNSProviderSolver) validate(cfg *powerDNSProviderConfig) error {
 	}
 
 	// Try to load the API key
-	if cfg.APIKeySecretRef.LocalObjectReference.Name == "" {
+	if cfg.APIKeySecretRef == nil || cfg.APIKeySecretRef.LocalObjectReference.Name == "" {
 		return errors.New("no PowerDNS API key provided")
 	}
 


### PR DESCRIPTION
Resolves a panic when the `apiKeySecretRef` field is not set on the
issuer configuration and properly outputs the message that the API key
secret name was not provided.
