### PR TITLE
Authorization header support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ spec:
               ### OPTIONAL
               ###
 
+              # API Key scheme https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
+              # default: no scheme ""
+              apiKeyScheme: ""
+
+              # Header name for API key
+              #
+              # This defaults to X-API-Key when unset but supports customizations
+              # e.g. Authorization 
+              apiKeyHeaderName: ""
+
               # Server ID for the PowerDNS API.
               # When unset, defaults to "localhost".
               #

--- a/main_test.go
+++ b/main_test.go
@@ -32,8 +32,16 @@ func TestNoProxyNoTLS(t *testing.T) {
 	test(t, "_out/testdata/no-tls")
 }
 
+func TestNoProxyNoTLSAuthHdr(t *testing.T) {
+	test(t, "_out/testdata/no-tls-auth-hdr")
+}
+
 func TestNoProxyTLS(t *testing.T) {
 	test(t, "_out/testdata/tls")
+}
+
+func TestNoProxyTLSAuthHdr(t *testing.T) {
+	test(t, "_out/testdata/tls-auth-hdr")
 }
 
 func TestProxyNoTLS(t *testing.T) {

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -21,14 +21,14 @@ EOF
 
 openssl req -x509 -config _out/openssl.conf -newkey rsa:4096 -keyout _out/key.pem -out _out/cert.pem -sha256 -days 30 -nodes -subj '/CN=localhost'
 
-for suite in tls tls-with-proxy; do
+for suite in tls tls-with-proxy tls-auth-hdr; do
   mkdir -p _out/testdata/${suite}
   cp testdata/pdns/test/${suite}/apikey.yml _out/testdata/${suite}/apikey.yml
   sed "s#__CERT__#$(base64 -w0 _out/cert.pem)#g" testdata/pdns/test/${suite}/config.json > _out/testdata/${suite}/config.json
 done
 
 # No TLS
-for suite in no-tls no-tls-with-proxy; do
+for suite in no-tls no-tls-with-proxy no-tls-auth-hdr; do
   mkdir -p _out/testdata/${suite}
   cp testdata/pdns/test/${suite}/{config.json,apikey.yml} _out/testdata/${suite}
 done

--- a/testdata/pdns/test/no-tls-auth-hdr/apikey.yml
+++ b/testdata/pdns/test/no-tls-auth-hdr/apikey.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pdns-api-key
+type: Opaque
+data:
+  key: dGVzdDEyMw==

--- a/testdata/pdns/test/no-tls-auth-hdr/config.json
+++ b/testdata/pdns/test/no-tls-auth-hdr/config.json
@@ -1,0 +1,10 @@
+{
+    "host": "http://127.0.0.1:8080",
+    "apiKeySecretRef": {
+        "name": "pdns-api-key",
+        "key": "key"
+    },
+    "apiKeyScheme": "",
+    "apiKeyHeaderName": "X-API-Key",
+    "ttl": 10
+}

--- a/testdata/pdns/test/tls-auth-hdr/apikey.yml
+++ b/testdata/pdns/test/tls-auth-hdr/apikey.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pdns-api-key
+type: Opaque
+data:
+  key: dGVzdDEyMw==

--- a/testdata/pdns/test/tls-auth-hdr/config.json
+++ b/testdata/pdns/test/tls-auth-hdr/config.json
@@ -1,0 +1,11 @@
+{
+    "host": "https://127.0.0.1:8443",
+    "apiKeySecretRef": {
+        "name": "pdns-api-key",
+        "key": "key"
+    },
+    "apiKeyScheme": "",
+    "apiKeyHeaderName": "X-API-Key",
+    "ttl": 10,
+    "caBundle": "__CERT__"
+}


### PR DESCRIPTION
Supports customizing authorization header where API key will be provided including schemes. 

https://github.com/zachomedia/cert-manager-webhook-pdns/issues/43