### PR TITLE
Bump to latest golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3-alpine AS build_deps
+FROM golang:1.22-alpine AS build_deps
 
 RUN apk add --no-cache git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zachomedia/cert-manager-webhook-pdns
 
-go 1.20
+go 1.22
 
 require (
 	github.com/cert-manager/cert-manager v1.12.2


### PR DESCRIPTION
Bump to latest golang version, to remediate a number of CVEs (below). Can we also cut a new release and image?

```bash
stdlib  go1.20.3  go-module  CVE-2023-29405  Critical
stdlib  go1.20.3  go-module  CVE-2023-29404  Critical
stdlib  go1.20.3  go-module  CVE-2023-29402  Critical
stdlib  go1.20.3  go-module  CVE-2023-24540  Critical
stdlib  go1.20.3  go-module  CVE-2023-45285  High
stdlib  go1.20.3  go-module  CVE-2023-44487  High
stdlib  go1.20.3  go-module  CVE-2023-39325  High
stdlib  go1.20.3  go-module  CVE-2023-39323  High
stdlib  go1.20.3  go-module  CVE-2023-29403  High
stdlib  go1.20.3  go-module  CVE-2023-29400  High
stdlib  go1.20.3  go-module  CVE-2023-24539  High
stdlib  go1.20.3  go-module  CVE-2023-39326  Medium
stdlib  go1.20.3  go-module  CVE-2023-39319  Medium
stdlib  go1.20.3  go-module  CVE-2023-39318  Medium
stdlib  go1.20.3  go-module  CVE-2023-29409  Medium
stdlib  go1.20.3  go-module  CVE-2023-29406  Medium
stdlib  go1.20.3  go-module  CVE-2024-24785  Unknown
stdlib  go1.20.3  go-module  CVE-2024-24784  Unknown
stdlib  go1.20.3  go-module  CVE-2024-24783  Unknown
stdlib  go1.20.3  go-module  CVE-2023-45290  Unknown
stdlib  go1.20.3  go-module  CVE-2023-45289  Unknown
```