### PR TITLE
Allow imagePullSecrets to be specified in values.yaml

### DIFF
--- a/deploy/cert-manager-webhook-pdns/Chart.yaml
+++ b/deploy/cert-manager-webhook-pdns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cert-manager-webhook-pdns
-version: 3.2.0
+version: 3.2.1
 description: Cert Manager Webhook for PowerDNS.
 type: application
 home: https://github.com/zachomedia/cert-manager-webhook-pdns

--- a/deploy/cert-manager-webhook-pdns/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-pdns/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       priorityClassName: {{ . | quote }}
       {{- end }}
       {{- if .Values.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/deploy/cert-manager-webhook-pdns/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-pdns/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"

--- a/deploy/cert-manager-webhook-pdns/values.yaml
+++ b/deploy/cert-manager-webhook-pdns/values.yaml
@@ -17,6 +17,11 @@ image:
   # tag: latest
   pullPolicy: IfNotPresent
 
+# -- Optional array of imagePullSecrets containing private registry credentials
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# - name: secretName
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
When pulling image from private registry, imagePullSecrets should be defined to point to secret containing the credentials for registry (.dockerconfigjson).