### PR TITLE
Allow volumes and volumeMounts to be specified

### DIFF
--- a/deploy/cert-manager-webhook-pdns/Chart.yaml
+++ b/deploy/cert-manager-webhook-pdns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cert-manager-webhook-pdns
-version: 3.2.1
+version: 3.2.2
 description: Cert Manager Webhook for PowerDNS.
 type: application
 home: https://github.com/zachomedia/cert-manager-webhook-pdns

--- a/deploy/cert-manager-webhook-pdns/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-pdns/templates/deployment.yaml
@@ -74,12 +74,18 @@ spec:
             - name: certs
               mountPath: /tls
               readOnly: true
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
         - name: certs
           secret:
             secretName: {{ include "cert-manager-webhook-pdns.servingCertificate" . }}
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/deploy/cert-manager-webhook-pdns/values.yaml
+++ b/deploy/cert-manager-webhook-pdns/values.yaml
@@ -66,6 +66,12 @@ podSecurityContext: {}
 
 priorityClassName: ""
 
+# Additional volumes to add to the cert-manager-webhook-pdns pod.
+volumes: []
+
+# Additional volume mounts to add to the cert-manager-webhook-pdns pod.
+volumeMounts: []
+
 # Configures the HTTP_PROXY environment variable where a HTTP proxy is required.
 # http_proxy: "http://proxy:8080"
 


### PR DESCRIPTION
This allow volumes and volumeMounts to be added to the cert-manager-webhook-pdns pod. This is useful, in my case, for adding CA certificates using a vault-synchronized secret rather than hard-coded in the caBundle config in the ClusterIssuer.